### PR TITLE
Switch from JSR to npm registry publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 name: Publish
+
 on:
   push:
     branches:
@@ -9,40 +10,49 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      packages: write
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
       - name: Check and publish packages
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          # Функция для проверки и публикации пакета
+          # Set npm registry and authentication
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+
+          # Function to check and publish package
           check_and_publish() {
             local package_path="$1"
-            local package_name=$(jq -r '.name' "$package_path/jsr.json")
-            local package_version=$(jq -r '.version' "$package_path/jsr.json")
+            local package_name=$(jq -r '.name' "$package_path/package.json")
+            local package_version=$(jq -r '.version' "$package_path/package.json")
 
             echo "Checking package: $package_name@$package_version"
 
-            # Проверяем, существует ли уже такая версия
-            if bunx jsr info "$package_name@$package_version" >/dev/null 2>&1; then
+            # Check if version already exists on npm
+            if bun pm view "$package_name@$package_version" version >/dev/null 2>&1; then
               echo "Version $package_version for $package_name already exists, skipping..."
               return 0
             fi
 
             echo "Publishing $package_name@$package_version..."
             cd "$package_path"
-            bunx jsr publish
+            bun publish --access public
             cd - >/dev/null
           }
 
-          # Находим все пакеты с jsr.json
-          find . -name "jsr.json" -type f | while read -r jsr_file; do
-            package_dir=$(dirname "$jsr_file")
+          # Find all packages with package.json
+          find . -name "package.json" -type f | while read -r package_file; do
+            package_dir=$(dirname "$package_file")
             check_and_publish "$package_dir"
           done

--- a/bun.lock
+++ b/bun.lock
@@ -71,7 +71,6 @@
     },
     "design-system/themes/default": {
       "name": "@rolder/theme-default",
-      "version": "0.1.0",
       "devDependencies": {
         "@pandacss/dev": "^1.4.0",
       },

--- a/design-system/themes/default/globalCss.ts
+++ b/design-system/themes/default/globalCss.ts
@@ -1,4 +1,4 @@
-import { defineGlobalStyles, type GlobalStyleObject } from "@pandacss/dev";
+import { defineGlobalStyles } from "@pandacss/dev";
 
 export default defineGlobalStyles({
 	"html, body": {
@@ -10,4 +10,4 @@ export default defineGlobalStyles({
 		lineHeight: "24px",
 		letterSpacing: "0",
 	},
-}) as GlobalStyleObject;
+});

--- a/design-system/themes/default/index.ts
+++ b/design-system/themes/default/index.ts
@@ -1,4 +1,4 @@
-import { definePreset, type Preset } from "@pandacss/dev";
+import { definePreset } from "@pandacss/dev";
 import globalCss from "./globalCss";
 import keyframes from "./keyframes";
 import semanticTokens from "./semanticTokens";
@@ -16,4 +16,4 @@ export default definePreset({
 		},
 	},
 	globalCss,
-}) as Preset;
+});

--- a/design-system/themes/default/jsr.json
+++ b/design-system/themes/default/jsr.json
@@ -1,6 +1,0 @@
-{
-	"name": "@rolder/theme-default",
-	"version": "0.3.0",
-	"license": "MIT",
-	"exports": "./index.ts"
-}

--- a/design-system/themes/default/keyframes.ts
+++ b/design-system/themes/default/keyframes.ts
@@ -1,4 +1,4 @@
-import { type CssKeyframes, defineKeyframes } from "@pandacss/dev";
+import { defineKeyframes } from "@pandacss/dev";
 
 export default defineKeyframes({
 	fadeOut: {
@@ -13,4 +13,4 @@ export default defineKeyframes({
 		"0%": { transform: "translateY(-8px)", opacity: "0" },
 		"100%": { transform: "translateY(0px)", opacity: "1" },
 	},
-}) as CssKeyframes;
+});

--- a/design-system/themes/default/package.json
+++ b/design-system/themes/default/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@rolder/theme-default",
+	"version": "0.3.0",
 	"description": "Default Rolder theme",
 	"type": "module",
 	"module": "./index.ts",

--- a/design-system/themes/default/semanticTokens.ts
+++ b/design-system/themes/default/semanticTokens.ts
@@ -1,4 +1,4 @@
-import { defineSemanticTokens, type SemanticTokens } from "@pandacss/dev";
+import { defineSemanticTokens } from "@pandacss/dev";
 
 export default defineSemanticTokens({
 	colors: {
@@ -167,4 +167,4 @@ export default defineSemanticTokens({
 			},
 		},
 	},
-}) as SemanticTokens;
+});

--- a/design-system/themes/default/textStyles.ts
+++ b/design-system/themes/default/textStyles.ts
@@ -1,4 +1,4 @@
-import { defineTextStyles, type TextStyles } from "@pandacss/dev";
+import { defineTextStyles } from "@pandacss/dev";
 
 export default defineTextStyles({
 	h3: {
@@ -37,4 +37,4 @@ export default defineTextStyles({
 			letterSpacing: "0",
 		},
 	},
-}) as TextStyles;
+});

--- a/design-system/themes/default/tokens/colors.ts
+++ b/design-system/themes/default/tokens/colors.ts
@@ -1,4 +1,4 @@
-import { defineTokens, type Tokens } from "@pandacss/dev";
+import { defineTokens } from "@pandacss/dev";
 
 export default defineTokens({
 	colors: {
@@ -75,4 +75,4 @@ export default defineTokens({
 			900: { value: "#041A2F" },
 		},
 	},
-}) as Tokens;
+});

--- a/design-system/themes/default/tokens/index.ts
+++ b/design-system/themes/default/tokens/index.ts
@@ -1,4 +1,4 @@
-import { defineTokens, type Tokens } from "@pandacss/dev";
+import { defineTokens } from "@pandacss/dev";
 import colors from "./colors";
 import shadows from "./shadows";
 
@@ -12,4 +12,4 @@ export default defineTokens({
 		lg: { value: "16px" },
 		full: { value: "9999px" },
 	},
-}) as Tokens;
+});

--- a/design-system/themes/default/tokens/shadows.ts
+++ b/design-system/themes/default/tokens/shadows.ts
@@ -1,4 +1,4 @@
-import { defineTokens, type Tokens } from "@pandacss/dev";
+import { defineTokens } from "@pandacss/dev";
 
 export default defineTokens({
 	shadows: {
@@ -57,4 +57,4 @@ export default defineTokens({
 			],
 		},
 	},
-}) as Tokens;
+});


### PR DESCRIPTION
The changes migrate the publishing workflow from JSR to npm registry, updates authentication, and removes unnecessary type assertions in theme files.